### PR TITLE
redefine ParsedObj

### DIFF
--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -8,14 +8,11 @@ type Language =
 
 type Token =
     | CODEBLOCK of string * Language
-    | LITERAL of string
-    | EMPHASIS of string
-    | STRONG of string
-    | INLINECODE of string
+    | LITERAL
     | WHITESPACE of size: int
-    | NUMBER of int
+    | NUMBER of string
     | EMPTYLINE
-    | HASH | PIPE | EQUAL | MINUS | PLUS | ASTERISK
+    | HASH | PIPE | EQUAL | MINUS | PLUS | ASTERISK | DOT
     | DASTERISK | TASTERISK | UNDERSCORE | DUNDERSCORE | TUNDERSCORE | TILDE | DTILDE
     | TTILDE | LSBRA | RSBRA | LBRA | RBRA | BSLASH | SLASH | LABRA | RABRA | LCBRA
     | RCBRA | BACKTICK | TBACKTICK | EXCLAMATION | ENDLINE | COLON | CARET

--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -17,30 +17,26 @@ type Token =
     | TTILDE | LSBRA | RSBRA | LBRA | RBRA | BSLASH | SLASH | LABRA | RABRA | LCBRA
     | RCBRA | BACKTICK | TBACKTICK | EXCLAMATION | ENDLINE | COLON | CARET
 
-type WordLst = string list
+type TFrmtedString = | Strong of TFrmtedString | Emphasis of TFrmtedString | Literal of string
+type InlineElement =
+    | FrmtedString of TFrmtedString
+    | Link of HyperText: TFrmtedString * URL: string
+    | Picture of Alt: string * URL: string
+type TLine = InlineElement list
 
-type URL = string
-
-type HyperText = WordLst
-
-type Element =
-    | FrmtedWordLst of WordLst
-    | Link of HyperText * URL
-    | Picture of WordLst * URL
-
-type ListType = UL | OL
-
-type Line = Element list
-
-type THeader = {HeaderName: WordLst; Level: int}
+type THeader = {HeaderName: TLine; Level: int}
 
 type Ttoc = {MaxDepth: int; HeaderLst: THeader list}
+
+type TListType = | UL | OL
+type TList = {ListType: TListType; ListItem: TListItem list; Depth: int}
+and TListItem = NestedList of TList | StringItem of TLine
 
 type ParsedObj =
     | CodeBlock of string * Language
     | Header of THeader
-    | List of ListType * Line * Depth: int
-    | Paragraph of Line list
-    | Quote of Line
-    | Table of Content: Line list * Height: int * Width: int
-    | Footnote of ID: int * Line
+    | List of TList
+    | Paragraph of TLine list
+    | Quote of TLine
+    | Table of Content: TLine list * Height: int * Width: int
+    | Footnote of ID: int * TLine


### PR DESCRIPTION
Simpler types(hopefully).

@Qieerb I think `Toc` can essentially be
```fsharp
type Toc = TList
```
because there is recursion in ToC as well, and `Toc` & `TList` can be rendered similarly.
Like so,

1. Main section
    * subsection
    * subsection
        * subsubsection
2. Second Main section

What's your opinion?