### PR TITLE
re-model TFrmtedString to allow multiple InlineElemts

### DIFF
--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -16,8 +16,8 @@ type Token =
     | TTILDE | LSBRA | RSBRA | LBRA | RBRA | BSLASH | SLASH | LABRA | RABRA | LCBRA
     | RCBRA | BACKTICK | TBACKTICK | EXCLAMATION | ENDLINE | COLON | CARET
 
-type TFrmtedString = | Strong of TFrmtedString | Emphasis of TFrmtedString | Literal of string | Code of string
-type InlineElement =
+type TFrmtedString = | Strong of InlineElement list | Emphasis of InlineElement list | Literal of string | Code of string
+and InlineElement =
     | FrmtedString of TFrmtedString
     | Link of HyperText: TFrmtedString * URL: string
     | Picture of Alt: string * URL: string

--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -16,7 +16,9 @@ type Token =
     | TTILDE | LSBRA | RSBRA | LBRA | RBRA | BSLASH | SLASH | LABRA | RABRA | LCBRA
     | RCBRA | BACKTICK | TBACKTICK | EXCLAMATION | ENDLINE | COLON | CARET
 
-type TFrmtedString = | Strong of InlineElement list | Emphasis of InlineElement list | Literal of string | Code of string
+type TFrmtedString =
+    | Strong of InlineElement list | Emphasis of InlineElement list
+    | Literal of string | Code of string
 and InlineElement =
     | FrmtedString of TFrmtedString
     | Link of HyperText: TFrmtedString * URL: string


### PR DESCRIPTION
allow
```
***strong em** only em **se** [em Google](https://google.com)*
```
***strong em** only em **se** [em Google](https://google.com)*

### Picture can be inside `Strong` and `Emphasis` as well.
If you examine the HTML code for the following:
```
*G Doodle ![Google Doodle](https://www.google.com/logos/doodles/2018/doodle-snow-games-day-14-6465015337975808-2xa.gif)*
```
*G Doodle ![Google Doodle](https://www.google.com/logos/doodles/2018/doodle-snow-games-day-14-6465015337975808-2xa.gif)*
