### PR TITLE
Tokens tline

### DIFF
--- a/FMark/FMarkProgram.fs
+++ b/FMark/FMarkProgram.fs
@@ -14,7 +14,7 @@ let main argv =
 
     // ############## EXAMPLE, NEEDS TIDYING UP ################
     match ifFileReadFrom results with
-    | None(_) -> failwithf "No input."
+    | None(_) -> ()
     | Some(instr,fname) -> 
         let strip chars s = (String.map (fun c -> if Seq.exists((=)c) chars then ' ' else c) s).Trim()
         let outFile = results.GetResult(Output,defaultValue=strip ".md" fname+".html")

--- a/FMark/HTMLGenDummy.fs
+++ b/FMark/HTMLGenDummy.fs
@@ -6,13 +6,13 @@ open Types
 let rec inlineHTMLGen elem =
     match elem with
     //| Strong(x) -> // recursive...
-    | Literal(s) -> s
-    | Strong(x) -> sprintf "<strong>%s</strong>" (elemListHTMLGen x)
+    | FrmtedString(Literal(s)) -> s
+    | FrmtedString(Strong(x)) -> sprintf "<strong>%s</strong>" (elemListHTMLGen x)
     | e -> failwithf "Unexpected element: %A" e
 
 and elemListHTMLGen elemLst = 
     let folder s x = s + (inlineHTMLGen x)
-    List.fold folder elemLst
+    List.fold folder "" elemLst
 
 let rec tableHTMLGenDummy tab =
     let getAlignment = function
@@ -24,7 +24,7 @@ let rec tableHTMLGenDummy tab =
         | false -> "d"
     let printCell s = function
                       | CellLine(line,h,ali) -> 
-                        let cellContents = HTMLGenObjDummy line
+                        let cellContents = elemListHTMLGen line
                         s + sprintf "<t%s%s>%s</t%s>" (getH h) (getAlignment ali) cellContents (getH h)
     let printRow s = 
         function
@@ -35,11 +35,10 @@ let rec tableHTMLGenDummy tab =
     List.fold printRow s tab.[1..]
     + "</tbody></table>"
 
-and HTMLGenObjDummy ob =
+and HTMLGenObjDummy (ob:ParsedObj) =
     let f ob = 
         match ob with
         | Table(t) -> tableHTMLGenDummy t
-        | CellContents(line) -> elemListHTMLGen line 
         | _ -> "Unexpected parsedObj"
     //(Result.bind f) ob
     f ob

--- a/FMark/Markalc/Markalc.fs
+++ b/FMark/Markalc/Markalc.fs
@@ -4,16 +4,6 @@ open Types
 open MarkalcShared
 open Expression
 
-type Cell with 
-    member c.GetToks = match c with 
-                           | Contents(toks,_,_) -> toks
-    member c.ReplaceTokens t = match c with 
-                               | Contents(_,head,align) -> Contents(t,head,align)
-    member c.GetHead = match c with 
-                       | Contents(_,head,_) -> head
-    member c.GetParams = match c with 
-                       | Contents(toks,head,align) -> toks,head,align
-
 type MapContents =
     | MapTok of Cell
     | MapExp of Expr * Cell

--- a/FMark/Markalc/Markalc.fs
+++ b/FMark/Markalc/Markalc.fs
@@ -11,6 +11,8 @@ type Cell with
                                | Contents(_,head,align) -> Contents(t,head,align)
     member c.GetHead = match c with 
                        | Contents(_,head,_) -> head
+    member c.GetParams = match c with 
+                       | Contents(toks,head,align) -> toks,head,align
 
 type MapContents =
     | MapTok of Cell

--- a/FMark/Parser/Parser.fs
+++ b/FMark/Parser/Parser.fs
@@ -109,7 +109,16 @@ let rec parseItem (rawToks: Token list) : Result<ParsedObj * Token list, string>
     let tableTransform =
         Markalc.parseEvaluateTable
         >> function
-        | Ok(rows) -> Table(rows)
+        | Ok(rows) -> 
+            let toPCellList cell = 
+                let toks,head,align = (cell.GetParams) 
+                let PCellLine = toks |> parseItemList |> (function | Ok(x,_) -> x | Error(e) -> [Literal(e)])
+                CellLine(PCellLine,head,align)
+            let toPRow row = 
+                let clst, rHead = row |> function | Cells(clst',rHead'') -> clst',rHead'
+                PCells(List.map toPCellList clst, rHead)// Create PRows
+            // For each row, unpack into Cell list
+            List.map toPRow rows |> Table
         | Error(toks)-> PreTable(toks)
 
     let toks = deleteLeadingEDNLINEs rawToks

--- a/FMark/Parser/Parser.fs
+++ b/FMark/Parser/Parser.fs
@@ -1,6 +1,7 @@
 module Parser
 open Types
 open ParserHelperFuncs
+open Markalc
 
 // helper functions
 
@@ -107,15 +108,15 @@ let parseParagraph toks =
 let rec parseItem (rawToks: Token list) : Result<ParsedObj * Token list, string> =
     // transform table rows into Table or Pretable depending if valid table.
     let tableTransform =
-        Markalc.parseEvaluateTable
+        parseEvaluateTable
         >> function
         | Ok(rows) -> 
-            let toPCellList cell = 
+            let toPCellList (cell:Cell) = 
                 let toks,head,align = (cell.GetParams) 
-                let PCellLine = toks |> parseItemList |> (function | Ok(x,_) -> x | Error(e) -> [Literal(e)])
-                CellLine(PCellLine,head,align)
+                let pCellLine = toks |> parseInLineElements |> (function | Ok(x,_) -> x | Error(e) -> [FrmtedString(Literal(e))])
+                CellLine(pCellLine,head,align)
             let toPRow row = 
-                let clst, rHead = row |> function | Cells(clst',rHead'') -> clst',rHead'
+                let clst, rHead = row |> function | Cells(clst',rHead') -> clst',rHead'
                 PCells(List.map toPCellList clst, rHead)// Create PRows
             // For each row, unpack into Cell list
             List.map toPRow rows |> Table

--- a/FMark/Parser/ParserTest.fs
+++ b/FMark/Parser/ParserTest.fs
@@ -261,8 +261,8 @@ let ``preprocess table test`` =
               |cell|*)
             [PIPE;  LITERAL "head"; PIPE; ENDLINE; PIPE; MINUS;MINUS;MINUS; PIPE; ENDLINE; PIPE; LITERAL "cell"; PIPE],
             ([Table
-                [Cells ([Contents ([LITERAL "head"],true,Left)],true);
-                 Cells ([Contents ([LITERAL "cell"],false,Left)],false)]])|>Ok,
+                [PCells ([CellLine ([FrmtedString(Literal "head")],true,Left)],true);
+                 PCells ([CellLine ([FrmtedString(Literal "cell")],false,Left)],false)]])|>Ok,
             "Sample table"
         );
         (

--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -59,4 +59,13 @@ type ParsedObj =
     | Table of PRow list
     | PreTable of Content: Token list list
     | Footnote of ID: int * TLine
-    | CellContents of TLine
+
+type Cell with 
+    member c.GetToks = match c with 
+                           | Contents(toks,_,_) -> toks
+    member c.ReplaceTokens t = match c with 
+                               | Contents(_,head,align) -> Contents(t,head,align)
+    member c.GetHead = match c with 
+                       | Contents(_,head,_) -> head
+    member c.GetParams = match c with 
+                         | Contents(toks,head,align) -> toks,head,align

--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -43,6 +43,12 @@ type Cell =
 type Row =
     | Cells of Cell list * Header:bool
 
+type PCell =
+    | CellLine of TLine * Header: bool * Align:Alignment
+
+type PRow =
+    | PCells of PCell list * Header:bool
+
 type ParsedObj =
     | CodeBlock of string * Language
     | Header of THeader
@@ -50,7 +56,7 @@ type ParsedObj =
     | List of TList
     | Paragraph of TLine list
     | Quote of TLine
-    | Table of Row list
+    | Table of PRow list
     | PreTable of Content: Token list list
     | Footnote of ID: int * TLine
     | CellContent of InlineElement

--- a/FMark/Types.fs
+++ b/FMark/Types.fs
@@ -59,4 +59,4 @@ type ParsedObj =
     | Table of PRow list
     | PreTable of Content: Token list list
     | Footnote of ID: int * TLine
-    | CellContent of InlineElement
+    | CellContents of TLine


### PR DESCRIPTION
Updated table rows to `PRows`. `PRows` contain `PCells` which are `Cells` with the `Token list` parsed into a `TLine`. Also fixes #49 and includes changes from #50 