### PR TITLE
Yarninstall

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,8 @@ fi
 
 if [[ $BUILD = "all" ]] || [[ $BUILD = "js" ]]; then
     echo "Running javascript build"
+    cd $BASE_DIR
+    yarn install
     cd $BASE_DIR/FMark/src/FMarkFable
     dotnet restore
     dotnet fable yarn-dev

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ $BUILD = "all" ]] || [[ $BUILD = "js" ]]; then
     echo "Running javascript build"
-    cd $BASE_DIR
+    cd $BASE_DIR/FMark
     yarn install
     cd $BASE_DIR/FMark/src/FMarkFable
     dotnet restore


### PR DESCRIPTION
Add yarn install to javascript build. If it is not there, cloning from source and running build.sh will fail.