### PR TITLE
Type change, Preparing for integration (#108)

### DIFF
--- a/FMark/src/Common/HTMLGen/HTMLGen.fs
+++ b/FMark/src/Common/HTMLGen/HTMLGen.fs
@@ -98,10 +98,9 @@ let strHeader header =
         |> attachSimpleTag tagName
 
 /// process inline footnotes
-let strInlineFootnote fnId =
-    let idStr = match fnId with | FtID i -> string i | RefID s -> string s
-    idStr
-    |> attachHTMLTag ("a", ["href", "#footnote-"+idStr], true)
+let strInlineFootnote s =
+    s
+    |> attachHTMLTag ("a", ["href", "#footnote-"+s], true)
     |> attachSimpleTag "sup"
 
 
@@ -195,8 +194,9 @@ let strBody pObjs =
         | CodeBlock (c, l) -> attachHTMLTag ("code", [("language", mapLang l)], true) c
         | Table rows -> strTable rows
         | List l -> strList l
-        | Header h -> strHeader h
-        | Footnote (fnId, _) -> strInlineFootnote fnId
+        | Header (h,s) -> strHeader h //#### DO SOMETHING WITH STRING HERE
+        | Footnote (i,_) -> strInlineFootnote (string i)
+        | Citation (s,_,_) -> strInlineFootnote s
         | ContentTable toc -> strToC toc
         | _ -> sprintf "%A is not implemented" pObj
     List.fold folder "" pObjs

--- a/FMark/src/Common/HTMLGen/HTMLGenTester.fs
+++ b/FMark/src/Common/HTMLGen/HTMLGenTester.fs
@@ -136,11 +136,11 @@ let headerTests =
 let inlineFootnoteTests =
     makeExpectoTestList id id strInlineFootnote "inline footnote tests" [
         (
-            FtID 3,
+            string 3,
             "<sup><a href=\"#footnote-3\">3</a></sup>", "footer 3"
         );
         (
-            RefID "abcd",
+            "abcd",
             "<sup><a href=\"#footnote-abcd\">abcd</a></sup>", "footer string"
         );
     ]
@@ -249,7 +249,7 @@ let fullBodyTests =
     makeExpectoTestList id catStr strBody "full body tests" [
         (
             [
-                Header{HeaderName=[FrmtedString(Literal "header")]; Level=1};
+                Header({HeaderName=[FrmtedString(Literal "header")]; Level=1},"HEADER STRING NOT IMPLEMENTED");
                 List{ListType=UL;ListItem=
                     [StringItem[FrmtedString(Literal "first")]; StringItem[FrmtedString(Literal "second")];
                         NestedList{ListType=OL;ListItem=
@@ -272,7 +272,7 @@ let ``global simple test`` =
     makeExpectoTestList id id genHTML "top level genHTML test" [
         ("FMarkToHtml first release",
             [
-                Header{HeaderName=[FrmtedString(Literal "header")]; Level=1};
+                Header({HeaderName=[FrmtedString(Literal "header")]; Level=1},"HEADER STRING NOT IMPLEMENTED");
                 List{ListType=UL;ListItem=
                     [StringItem[FrmtedString(Literal "first")]; StringItem[FrmtedString(Literal "second")];
                         NestedList{ListType=OL;ListItem=

--- a/FMark/src/Common/MarkdownGen/MarkdownGen.fs
+++ b/FMark/src/Common/MarkdownGen/MarkdownGen.fs
@@ -118,7 +118,7 @@ let mdBody pObjs =
         | CodeBlock (c, l) -> surround "```" (mapLang l + "\n" + c + "\n")
         | Table rows -> mdTable rows
         | List l -> mdList l |> sprintf "%s\n"
-        | Header h -> mdHeader h
+        | Header (h,s) -> mdHeader h //#### DO SOMETHING WITH STRING HERE
         //| Footnote (fnId, _) -> mdInlineFootnote fnId
         | _ -> sprintf "%A is not implemented" pObj
     List.fold folder "" pObjs

--- a/FMark/src/Common/MarkdownGen/MarkdownGenTester.fs
+++ b/FMark/src/Common/MarkdownGen/MarkdownGenTester.fs
@@ -160,7 +160,7 @@ let fullBodyTests =
     makeExpectoTestList id catStr mdBody "full body tests" [
         (
             [
-                Header{HeaderName=[FrmtedString(Literal "header")]; Level=1};
+                Header({HeaderName=[FrmtedString(Literal "header")]; Level=1},"HEADER STRING NOT IMPLEMENTED");
                 List{ListType=UL;ListItem=
                     [StringItem[FrmtedString(Literal "first")]; StringItem[FrmtedString(Literal "second")];
                         NestedList{ListType=OL;ListItem=

--- a/FMark/src/Common/Parser/Parser.fs
+++ b/FMark/src/Common/Parser/Parser.fs
@@ -17,40 +17,6 @@ let rec parseCode toks =
     | e ->  sharedLog.Warn None (sprintf "%A" e)
             ("\\`", xOnwards 1 toks) |> Ok
 
-/// parse inline text, including links and pictures, terminates when nothing left
-let parseInLineElements toks =
-    let attachInlineEle front back ele =
-        [front;ele;back]
-    let rec parseInLineElements' currentLine toks =
-        match toks with
-        | MatchSym BACKTICK (content, rtks) -> (content|> strAllToks|> Code|> FrmtedString )::currentLine, rtks
-        | MatchEm (content, rtks, frontLiteral, backLiteral) ->
-            let inlineContent = (parseInLines [] content |> Emphasis |> FrmtedString)
-            match frontLiteral, backLiteral with
-                | Some fl, Some bl ->
-                    [bl;inlineContent;fl]
-                | Some fl, None ->
-                    [inlineContent;fl]
-                | None, Some bl ->
-                    [bl;inlineContent]
-                | None, None ->
-                    [inlineContent]
-            |> (fun x -> x@currentLine), rtks
-        | _ ->
-            let str = mapTok toks.[0]
-            FrmtedString (Literal str)::currentLine, xOnwards 1 toks
-    and parseInLines currentLine toks =
-        match toks with
-        | [] -> []
-        | _ ->
-            let (newLine, retoks) = parseInLineElements' currentLine toks
-            match retoks with
-            | [] -> newLine |> List.rev
-            | _ ->
-                parseInLines newLine retoks
-                |> combineLiterals
-    parseInLines [] toks
-
 /// parse a paragraph which counts for contents in  `<p>`
 /// parseParagraph eats 2>= ENDLINEs
 let parseParagraph toks =
@@ -103,7 +69,7 @@ let rec parseItem (rawToks: Token list) : Result<ParsedObj * Token list, string>
         |> Ok
     | MatchHeader (level, content, rtks) ->
         let line = parseInLineElements content
-        (Header{HeaderName=line; Level=level}, rtks)
+        (Header({HeaderName=line; Level=level},"HEADER STRING NOT IMPLEMENTED"), rtks)
         |> Ok
     | PickoutParagraph (par, retoks) ->
         (parseParagraph par, retoks) |> Ok

--- a/FMark/src/Common/Parser/ParserTest.fs
+++ b/FMark/src/Common/Parser/ParserTest.fs
@@ -210,7 +210,7 @@ let testGlobal =
         );
         (
             [HASH; HASH; WHITESPACE 2; LITERAL "h2"],
-            [Header{HeaderName=[FrmtedString(Literal "h2")]; Level=2}] |>Ok, "h2 header"
+            [Header({HeaderName=[FrmtedString(Literal "h2")]; Level=2},"HEADER STRING NOT IMPLEMENTED")] |>Ok, "h2 header"
         );
         (
             [HASH; HASH; LITERAL "h2"],

--- a/FMark/src/Common/Shared.fs
+++ b/FMark/src/Common/Shared.fs
@@ -32,7 +32,8 @@ let (|CharTok|_|) tok =
 let mapTok = function
     | CharTok s -> s
     | CODEBLOCK _ -> "CODEBLOCK"
-    | FOOTER _ -> sprintf "FOOTER found"
+    | FOOTNOTE _ -> sprintf "FOOTNOTE found"
+    | CITATION _ -> sprintf "CITATION found"
     | HEADER n -> sprintf "HEADER %d" n
     | NUMBER s -> s
     | LITERAL s -> s

--- a/FMark/src/Common/TOCite/RefParse.fs
+++ b/FMark/src/Common/TOCite/RefParse.fs
@@ -148,7 +148,7 @@ let ref2TLine format ref:TLine =
 
 // parses a single reference entry
 // This probably should never see ENDLINE
-let refParser frmt tLst =
+let refParser style tLst =
     let rec refPar' refData tLst =
         let rec refParse' parsing tail =
             match tail with
@@ -188,4 +188,15 @@ let refParser frmt tLst =
     tLst    
     |> refPar' {Cat = None; Author = None; Title = None;
                     Year = None; AccessDate = None; URL = None}
-    |> fun (x,_) -> ref2TLine frmt x
+    |> fun (x,_) -> refInLine style x, ref2TLine style x
+
+
+// parse references with refParser
+let refParse style tocLst =
+    let ind = tocLst |> List.tryFindIndex (fun x -> x = ENDLINE)
+    match ind with
+    | Some i ->
+        let (h,t) = List.splitAt i tocLst
+        refParser style h |> fun (a,b) -> a,b,t.Tail
+    | None ->
+        refParser style tocLst |> fun (a,b) -> a,b,[]

--- a/FMark/src/Common/TOCite/RefParseTest.fs
+++ b/FMark/src/Common/TOCite/RefParseTest.fs
@@ -41,43 +41,43 @@ let testDataRefHarvard =
     [LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Zifan"; WHITESPACE 1;
         LITERAL "Wang"],
     Harvard,
-    [FrmtedString (Literal "Wang, "); FrmtedString (Literal "Z. ")];
+    ([],[FrmtedString (Literal "Wang, "); FrmtedString (Literal "Z. ")]);
 
     "Harvard Author with multiple given names",
     [LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Zifan"; WHITESPACE 1;
         LITERAL "Eric"; WHITESPACE 1; LITERAL "Wang"],
     Harvard,
-    [FrmtedString (Literal "Wang, "); FrmtedString (Literal "E. ");
-        FrmtedString (Literal "Z. ")];
+    ([],[FrmtedString (Literal "Wang, "); FrmtedString (Literal "E. ");
+        FrmtedString (Literal "Z. ")]);
 
     "Harvard Title only",
     [LITERAL "title";EQUAL; WHITESPACE 1; LITERAL "Book1"],
     Harvard,
-    [FrmtedString (Emphasis [FrmtedString (Literal "Book1. ")])];
+    ([],[FrmtedString (Emphasis [FrmtedString (Literal "Book1. ")])]);
 
     "Harvard Title with multiple words",
     [LITERAL "title";EQUAL; WHITESPACE 1; LITERAL "Book1"; WHITESPACE 1;
         LITERAL "Subtitle"],
     Harvard,
-    [FrmtedString (Emphasis [FrmtedString (Literal "Book1 Subtitle. ")])];
+    ([],[FrmtedString (Emphasis [FrmtedString (Literal "Book1 Subtitle. ")])]);
 
     "Harvard Year only",
     [LITERAL "year";EQUAL; WHITESPACE 1; NUMBER "2018"],
     Harvard,
-    [FrmtedString (Literal "(2018) ")];
+    ([],[FrmtedString (Literal "(2018) ")]);
 
     "Harvard URL only",
     [LITERAL "url";EQUAL; WHITESPACE 1; LITERAL "www.example.com"],
     Harvard,
-    [FrmtedString (Literal "Available from: ");
+    ([],[FrmtedString (Literal "Available from: ");
         Link (Literal "www.example.com","www.example.com");
-        FrmtedString (Literal " ")];
+        FrmtedString (Literal " ")]);
 
     "Harvard Access date only",
     [LITERAL "access";EQUAL; WHITESPACE 1; NUMBER "2018"; MINUS; NUMBER "3";
         MINUS; NUMBER "8"],
     Harvard,
-    [FrmtedString (Literal "[Accessed 8th March 2018]. ")];
+    ([],[FrmtedString (Literal "[Accessed 8th March 2018]. ")]);
 
     "Harvard Book reference",
     [LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Zifan"; WHITESPACE 1;
@@ -85,9 +85,12 @@ let testDataRefHarvard =
         LITERAL "Not a real book"; COMMA; LITERAL "year"; EQUAL; WHITESPACE 1;
         NUMBER "2018"],
     Harvard,
-    [FrmtedString (Literal "Wang, "); FrmtedString (Literal "Z. ");
-        FrmtedString (Literal "(2018) ");
-        FrmtedString (Emphasis [FrmtedString (Literal "Not a real book. ")])]
+    (
+        [FrmtedString (Literal "(Zifan 2018)")],
+        [FrmtedString (Literal "Wang, "); FrmtedString (Literal "Z. ");
+            FrmtedString (Literal "(2018) ");
+            FrmtedString (Emphasis [FrmtedString (Literal "Not a real book. ")])]
+    )
 
     "Harvard Website reference",
     [LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Eric"; WHITESPACE 1;
@@ -98,12 +101,15 @@ let testDataRefHarvard =
         LITERAL "access"; EQUAL; WHITESPACE 1; NUMBER "2018"; MINUS; NUMBER "2";
         MINUS; NUMBER "4"],
     Harvard,
-    [FrmtedString (Literal "Wang, "); FrmtedString (Literal "E. ");
-        FrmtedString (Literal "(2017) ");
-        FrmtedString (Emphasis [FrmtedString (Literal "Not a real website. ")]);
-        FrmtedString (Literal "Available from: ");
-        Link (Literal "www.example.com/website","www.example.com/website");
-        FrmtedString (Literal " "); FrmtedString (Literal "[Accessed 4th February 2018]. ")]
+    (
+        [FrmtedString (Literal "(Eric 2017)")],
+        [FrmtedString (Literal "Wang, "); FrmtedString (Literal "E. ");
+            FrmtedString (Literal "(2017) ");
+            FrmtedString (Emphasis [FrmtedString (Literal "Not a real website. ")]);
+            FrmtedString (Literal "Available from: ");
+            Link (Literal "www.example.com/website","www.example.com/website");
+            FrmtedString (Literal " "); FrmtedString (Literal "[Accessed 4th February 2018]. ")]
+    )
 
     ]
 
@@ -114,46 +120,46 @@ let testDataRefChicago =
         LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Zifan"; WHITESPACE 1;
         LITERAL "Wang"],
     Chicago,
-    [FrmtedString (Literal "Zifan Wang. ")];
+    ([],[FrmtedString (Literal "Zifan Wang. ")]);
 
     "Chicago Author with multiple given names",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Book"; COMMA;
         LITERAL "author"; EQUAL; WHITESPACE 1; LITERAL "Zifan"; WHITESPACE 1;
         LITERAL "Eric"; WHITESPACE 1; LITERAL "Wang"],
     Chicago,
-    [FrmtedString (Literal "Zifan Eric Wang. ")];
+    ([],[FrmtedString (Literal "Zifan Eric Wang. ")]);
 
     "Chicago Title only",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Book"; COMMA;
         LITERAL "title";EQUAL; WHITESPACE 1; LITERAL "Book1"],
     Chicago,
-    [FrmtedString (Emphasis [FrmtedString (Literal "Book1. ")])];
+    ([],[FrmtedString (Emphasis [FrmtedString (Literal "Book1. ")])]);
 
     "Chicago Title with multiple words",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Book"; COMMA;
         LITERAL "title";EQUAL; WHITESPACE 1; LITERAL "Book1"; WHITESPACE 1;
         LITERAL "Subtitle"],
     Chicago,
-    [FrmtedString (Emphasis [FrmtedString (Literal "Book1 Subtitle. ")])];
+    ([],[FrmtedString (Emphasis [FrmtedString (Literal "Book1 Subtitle. ")])]);
 
     "Chicago Year only",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Book"; COMMA;
         LITERAL "year";EQUAL; WHITESPACE 1; NUMBER "2018"],
     Chicago,
-    [FrmtedString (Literal "2018. ")];
+    ([],[FrmtedString (Literal "2018. ")]);
 
     "Chicago URL only",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Website"; COMMA;
         LITERAL "url";EQUAL; WHITESPACE 1; LITERAL "www.example.com"],
     Chicago,
-    [Link (Literal "www.example.com","www.example.com")];
+    ([],[Link (Literal "www.example.com","www.example.com")]);
 
     "Chicago Access date only",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Website"; COMMA;
         LITERAL "access";EQUAL; WHITESPACE 1; NUMBER "2018"; MINUS; NUMBER "8";
         MINUS; NUMBER "8"],
     Chicago,
-    [FrmtedString (Literal "Accessed August 8, 2018. ")];
+    ([],[FrmtedString (Literal "Accessed August 8, 2018. ")]);
 
     "Chicago Book reference",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Book"; COMMA;
@@ -162,8 +168,11 @@ let testDataRefChicago =
         LITERAL "Not a real book"; COMMA; LITERAL "year"; EQUAL; WHITESPACE 1;
         NUMBER "2018"],
     Chicago,
-    [FrmtedString (Literal "Zifan Wang. "); FrmtedString (Literal "2018. ");
-        FrmtedString (Emphasis [FrmtedString (Literal "Not a real book. ")])]
+    (
+        [FrmtedString (Literal "(Zifan, 2018)")],
+        [FrmtedString (Literal "Zifan Wang. "); FrmtedString (Literal "2018. ");
+            FrmtedString (Emphasis [FrmtedString (Literal "Not a real book. ")])]
+    );
 
     "Chicago Website reference",
     [LITERAL "type";EQUAL; WHITESPACE 1; LITERAL "Website"; COMMA;
@@ -175,10 +184,13 @@ let testDataRefChicago =
         LITERAL "access"; EQUAL; WHITESPACE 1; NUMBER "2018"; MINUS; NUMBER "3";
         MINUS; NUMBER "4"],
     Chicago,
-    [FrmtedString (Literal "Eric Wang. "); FrmtedString (Literal "2017. ");
-        FrmtedString (Literal "\"Not a real website.\" ");
-        FrmtedString (Literal "Accessed March 4, 2018. ");
-        Link (Literal "www.example.com/website","www.example.com/website")]
+    (
+        [FrmtedString (Literal "(Eric, 2017)")],
+        [FrmtedString (Literal "Eric Wang. "); FrmtedString (Literal "2017. ");
+            FrmtedString (Literal "\"Not a real website.\" ");
+            FrmtedString (Literal "Accessed March 4, 2018. ");
+            Link (Literal "www.example.com/website","www.example.com/website")]
+    )
 
     ]
 

--- a/FMark/src/Common/TOCite/TOC.fsproj
+++ b/FMark/src/Common/TOCite/TOC.fsproj
@@ -13,7 +13,6 @@
     <Compile Include="../Markalc/Expression.fs" />
     <Compile Include="../Markalc/Markalc.fs" />
     <Compile Include="../Parser/ParserHelperFuncs.fs" />
-    <Compile Include="../Parser/Parser.fs" />
     <Compile Include="RefParse.fs" />
     <Compile Include="TOCite.fs" />
     <Compile Include="RefParseTest.fs" />

--- a/FMark/src/Common/TOCite/TOCiteTest.fs
+++ b/FMark/src/Common/TOCite/TOCiteTest.fs
@@ -98,7 +98,7 @@ let testDataFt = [
     "Basic footer text",
     [LSBRA; CARET; NUMBER "1"; RSBRA; COMMA; LITERAL "text1"; LITERAL "text2"; ENDLINE],
     (
-        [Footnote (FtID 1, [FrmtedString (Literal "text1text2")])],
+        [Footnote (1, [FrmtedString (Literal "text1text2")])],
         []
     );
 
@@ -108,7 +108,7 @@ let testDataFt = [
         WHITESPACE 1; LITERAL "Not a real book"; COMMA; LITERAL "year"; EQUAL;
         WHITESPACE 1; LITERAL "2018"; ENDLINE],
     (
-        [Footnote (RefID "Eric", [FrmtedString (Literal "Wang, ");
+        [Citation ("Eric",[], [FrmtedString (Literal "Wang, ");
             FrmtedString (Literal "Z. ");
             FrmtedString (Emphasis [FrmtedString(Literal "Not a real book. ")])])],
         []
@@ -119,7 +119,7 @@ let testDataFt = [
         LITERAL "textAfter"; ENDLINE],
     (
         [],
-        [LITERAL "textbefore"; FOOTER (FtID 3); LITERAL "textAfter"; ENDLINE]
+        [LITERAL "textbefore"; FOOTNOTE 3; LITERAL "textAfter"; ENDLINE]
     );
 
     "Basic reference within text",
@@ -127,7 +127,7 @@ let testDataFt = [
         LITERAL "textAfter"; ENDLINE],
     (
         [],
-        [LITERAL "textbefore"; FOOTER (RefID "Eric"); LITERAL "textAfter"; ENDLINE]
+        [LITERAL "textbefore"; CITATION "Eric"; LITERAL "textAfter"; ENDLINE]
     );
 
     "Fake footer",
@@ -142,16 +142,16 @@ let testDataFt = [
         ENDLINE; WHITESPACE 4; LITERAL "text2"; ENDLINE; 
         LITERAL "text3";ENDLINE],
     (
-        [Footnote (FtID 2, [FrmtedString (Literal "text1text2")]);],
+        [Footnote (2, [FrmtedString (Literal "text1text2")]);],
         [LITERAL "text3"; ENDLINE]
     );
 
-    "Footer texts sorting",
+    "Footer texts no sorting",
     [LSBRA; CARET; NUMBER "3"; RSBRA; COMMA; LITERAL "text3"; ENDLINE;
         LSBRA; CARET; NUMBER "1"; RSBRA; COMMA; LITERAL "text1"; ENDLINE],
     (
-        [Footnote (FtID 1,[FrmtedString (Literal "text1")]);
-            Footnote (FtID 3,[FrmtedString (Literal "text3")])],
+        [Footnote (3,[FrmtedString (Literal "text3")]);
+            Footnote (1,[FrmtedString (Literal "text1")])],
         []
     )
 
@@ -159,7 +159,7 @@ let testDataFt = [
     [LSBRA; CARET; NUMBER "1"; RSBRA; COMMA; WHITESPACE 1; UNDERSCORE;
         LITERAL "text1"; UNDERSCORE; WHITESPACE 1; LITERAL "text2"; ENDLINE],
     (
-        [Footnote (FtID 1,[FrmtedString (Literal " ");
+        [Footnote (1,[FrmtedString (Literal " ");
             FrmtedString (Emphasis [FrmtedString (Literal "text1")]);
             FrmtedString (Literal " text2")])],
         []
@@ -186,8 +186,8 @@ let testDataFull =
     (
         [],
         [],
-        [LITERAL "textbefore"; FOOTER (FtID 3); LITERAL "textBetween";
-            FOOTER (RefID "Eric"); LITERAL "textAfter"; ENDLINE]
+        [LITERAL "textbefore"; FOOTNOTE 3; LITERAL "textBetween";
+            CITATION "Eric"; LITERAL "textAfter"; ENDLINE]
     )
 
     "Stupidly big test",
@@ -207,9 +207,11 @@ let testDataFull =
         MINUS; NUMBER "4"; ENDLINE],
     (
         [{HeaderName = [FrmtedString (Literal "Header1")]; Level = 1;}],
-        [Footnote (FtID 1,[FrmtedString (Literal "footer1")]);
-            Footnote (
-                RefID "Eric", [FrmtedString (Literal "Eric Wang. ");
+        [Footnote (1,[FrmtedString (Literal "footer1")]);
+            Citation (
+                "Eric",
+                [FrmtedString (Literal "(Eric, 2017)")],
+                [FrmtedString (Literal "Eric Wang. ");
                 FrmtedString (Literal "2017. ");
                 FrmtedString (Literal "\"Not a real website.\" ");
                 FrmtedString (Literal "Accessed March 4, 2018. ");
@@ -217,8 +219,8 @@ let testDataFull =
             )
         ],
         [ENDLINE; LITERAL "text1"; HASH; LITERAL "text2"; HEADER 0; ENDLINE;
-            LITERAL "text3"; FOOTER (FtID 1); LITERAL "text4"; ENDLINE; ENDLINE;
-            LITERAL "text5"; FOOTER (RefID "Eric"); LITERAL "text6"; ENDLINE; ENDLINE]
+            LITERAL "text3"; FOOTNOTE 1; LITERAL "text4"; ENDLINE; ENDLINE;
+            LITERAL "text5"; CITATION "Eric"; LITERAL "text6"; ENDLINE; ENDLINE]
     )
     
     ]

--- a/FMark/src/Common/Types.fs
+++ b/FMark/src/Common/Types.fs
@@ -7,8 +7,6 @@ type Language =
     | C
     | Empty
 
-type ID = FtID of int | RefID of string
-
 type Token =
     | CODEBLOCK of string * Language
     | LITERAL of string
@@ -18,8 +16,7 @@ type Token =
     | DASTERISK | TASTERISK | UNDERSCORE | DUNDERSCORE | TUNDERSCORE | TILDE | DTILDE
     | TTILDE | LSBRA | RSBRA | LBRA | RBRA | BSLASH | SLASH | LABRA | RABRA | LCBRA
     | RCBRA | BACKTICK | EXCLAMATION | ENDLINE | COLON | CARET | PERCENT | SEMICOLON
-    | HEADER of int
-    | FOOTER of ID
+    | HEADER of int | FOOTNOTE of int | CITATION of string
 
 type TFrmtedString =
     | Strong of InlineElement list | Emphasis of InlineElement list
@@ -60,15 +57,16 @@ type Ref = {Cat: RefType option; Author: Token list option; Title: Token list op
 
 type ParsedObj =
     | CodeBlock of string * Language
-    | Header of THeader
+    | Header of THeader * string
     | ContentTable of Ttoc
     | List of TList
     | Paragraph of TLine list
     | Quote of TLine
     | Table of PRow list
     | PreTable of Content: Token list list
-    | Footnote of ID * TLine
-
+    | Footnote of int * TLine
+    | Citation of string * TLine * TLine //ID,Inline,End of doc
+    
 type Cell with 
     member c.GetToks = match c with 
                            | Contents(toks,_,_) -> toks


### PR DESCRIPTION
After discussions with @ThunderMikey on #108, we decided to changes to type needed for integration.

* Header as a parsedObj now contains its string used in HTML linking.
* Footnotes and Citations now seperate.

The header change broke a few things in HTMLGen but is hacked together so now it builds successfully
They are marked with `//#### DO SOMETHING WITH STRING HERE` or `,"HEADER STRING NOT IMPLEMENTED"`